### PR TITLE
Fix kernel patch hash

### DIFF
--- a/configs/kernel.nix
+++ b/configs/kernel.nix
@@ -41,7 +41,7 @@ in {
         "sha256-2RBeX5vFN88GVgRkzwK/7Gzl2iSWr4OqkdqoSgJPml0="
         "sha256-oyR4traQbjq0+OMVL8q6UZicBh43TKN1BlhZsCTy7aU="
         "sha256-2RBeX5vFN88GVgRkzwK/7Gzl2iSWr4OqkdqoSgJPml0="
-        "sha256-10NUX/GOPL/t4YCPP5D2iE6j44BJHfYB+62Hq9eXKmA="
+        "sha256-05VnWFMMar7YILTHVh9RLueRlW00pk3CjGKT7XDb7D0="
         "sha256-qOZaHfZMc7Y2A0LdDJDO3Zi7QbdsBxZZoPmYKahkznw="
       ];
     in


### PR DESCRIPTION
Fix incorrect hash causes run nix develop fail.
```sh
$ nix develop github:jordanisaacs/kernel-module-flake
error: hash mismatch in fixed-output derivation '/nix/store/rf7lvs4npiff4r2p9g9000lfv16s3hsn-raw.drv':
         specified: sha256-10NUX/GOPL/t4YCPP5D2iE6j44BJHfYB+62Hq9eXKmA=
            got:    sha256-05VnWFMMar7YILTHVh9RLueRlW00pk3CjGKT7XDb7D0=
error: 1 dependencies of derivation '/nix/store/fahwliqsz30qg0afhanxg5ri3nzm31f2-linux-6.1.4.drv' failed to build
error: 1 dependencies of derivation '/nix/store/zs0h2z9wskj8fn75aarhbgdxl5xiv2zk-nix-shell-env.drv' failed to build
```