### PR TITLE
.gitignore: ignore .direnv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ rust-project.json
 /.tmp
 result
 result-dev
+
+.direnv


### PR DESCRIPTION
**Description**

Ignore `.direnv`, the temporary directory for files generated by direnv at run time.

**Motivation**

Temporary files, like those inside `.direnv` is not expected in the source tree. This PR makes it easier to develop this project with Git.